### PR TITLE
Update USBBoardInfo.json to include 3DR Control Zero OEM G

### DIFF
--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -50,6 +50,7 @@
         { "vendorID": 9900, "productID": 4130,      "boardClass": "Pixhawk",    "name": "mRo Control Zero Classic" },
         { "vendorID": 9900, "productID": 4131,      "boardClass": "Pixhawk",    "name": "mRo Control Zero H7" },
         { "vendorID": 9900, "productID": 4132,      "boardClass": "Pixhawk",    "name": "mRo Control Zero H7 OEM" },
+        { "vendorID": 9900, "productID": 4388,      "boardClass": "Pixhawk",    "name": "3DR Control Zero H7 OEM Rev G" },
 
         { "vendorID": 1027, "productID": 24597,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "3DR Radio" },
         { "vendorID": 1027, "productID": 24577,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "3DR Radio on FTDI" },


### PR DESCRIPTION
<!--- Title -->
Backport to stable for 3DR Control Zero H7 OEM Rev G
Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.